### PR TITLE
One fixms script / expansion of pol_axes to get third-axis orientation

### DIFF
--- a/fixms/fix_ms.py
+++ b/fixms/fix_ms.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Utility to correct the ASKAP beam positions and apply a rotation
+to apply a change of the reference frame of the visibilities
+"""
+import logging 
+from argparse import ArgumentParser
+from pathlib import Path
+
+import numpy as np 
+
+from fixms.fix_ms_corrs import fix_ms_corrs
+from fixms.fix_ms_dir import fix_ms_dir
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+def get_parser() -> ArgumentParser:
+    parser = ArgumentParser(description=__doc__)
+
+    parser.add_argument(
+        "ms", help="Measurement set to update", type=str, default=None, nargs="?"
+    )
+
+    parser.add_argument(
+        "--chunksize",
+        type=int,
+        default=1000,
+        help="The chunksize to use when reading the MS",
+    )
+    parser.add_argument(
+        "--data-column", type=str, default="DATA", help="The column to fix"
+    )
+    parser.add_argument(
+        "--corrected-data-column",
+        type=str,
+        default="CORRECTED_DATA",
+        help="The column to write the corrected data to",
+    )
+    
+    return parser 
+
+def cli() -> None:
+
+    parser = get_parser()
+
+    args = parser.parse_args()
+    
+    fix_ms_dir(args.ms)
+    
+    fix_ms_corrs(
+        Path(args.ms),
+        chunksize=args.chunksize,
+        data_column=args.data_column,
+        corrected_data_column=args.corrected_data_column,
+    )
+    
+    
+if __name__ == '__main__':
+    cli()
+

--- a/fixms/fix_ms_corrs.py
+++ b/fixms/fix_ms_corrs.py
@@ -11,7 +11,7 @@ The new correlations are placed in a new column called 'CORRECTED_DATA'
 __author__ = ["Alec Thomson"]
 import logging
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Optional
 
 import astropy.units as u
 import numpy as np
@@ -22,13 +22,17 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def get_pol_axis(ms: Path) -> u.Quantity:
+def get_pol_axis(ms: Path, feed_idx: Optional[int]=None) -> u.Quantity:
     """Get the polarization axis from the ASKAP MS. Checks are performed
     to ensure this polarisation axis angle is constant throughout the observation.
 
 
     Args:
         ms (Path): The path to the measurement set that will be inspected
+        feed_idx (Optional[int], optional): Specify the entery in the FEED
+        table of `ms` to return. This might be required when a subset of a
+        measurement set has beene extracted from an observation with a varying
+        orientation. 
 
     Returns:
         astropy.units.Quantity: The rotation of the PAF throughout the observing.
@@ -37,11 +41,17 @@ def get_pol_axis(ms: Path) -> u.Quantity:
         ms_feed = tf.getcol("RECEPTOR_ANGLE") * u.rad
         pol_axes = -(ms_feed - 45.0 * u.deg)
 
-    assert (ms_feed[:, 0] == ms_feed[0, 0]).all() & (
-        ms_feed[:, 1] == ms_feed[0, 1]
-    ).all(), "The RECEPTOR_ANGLE changes with time, please check the MS"
-    return pol_axes[0, 0].to(u.deg)
+    if feed_idx is None:
+        assert (ms_feed[:, 0] == ms_feed[0, 0]).all() & (
+            ms_feed[:, 1] == ms_feed[0, 1]
+        ).all(), "The RECEPTOR_ANGLE changes with time, please check the MS"
+        
+        pol_ang = pol_axes[0, 0].to(u.deg)
+    else:
+        logger.debug(f"Extracting the third-axis orientation for {feed_idx=}")
+        pol_ang = pol_axes[feed_idx, 0].to(u.deg)
 
+    return pol_ang
 
 def convert_correlations(correlations: np.ndarray, pol_axis: u.Quantity) -> np.ndarray:
     """
@@ -232,8 +242,21 @@ def fix_ms_corrs(
             )
             return
 
+        feed1 = np.unique(tab.getcol('FEED1'))
+        feed2 = np.unique(tab.getcol('FEED2'))
+
+        # For some ASKAP observations the orientation of the third-axis changes throughout
+        # the observation. For example, bandpass observations vary this direction as each
+        # beam cycles in the footprint cycles over the calibrator source. 
+        assert len(feed1) == 1 and len(feed2) == 1, f"More than one"
+        assert feed1[0] == feed2[0], f"The unique feed enteries availbe in the data table differ, {feed1=} {feed2=}"    
+        
+        # The two assertions above should enfore enough constraint 
+        # to make sure the rotation matix constructed is correct
+        feed_idx = feed1[0]
+
     # Get the polarization axis
-    pol_axis = get_pol_axis(ms)
+    pol_axis = get_pol_axis(ms, feed_idx=feed_idx)
     logger.info(f"Polarization axis is {pol_axis}")
 
     # Get the data chunk by chunk and convert the correlations


### PR DESCRIPTION
Part of this request is the 'one script' to apply correction for both the beam direction and the frame the visibilities are in. it currently does NOT have the `INSTRUMENT_DATA` column feature we discussed. 

I have also found a situation where the orientation of the third-axis changes throughout an observation. In my case it was happening to the data throughout a bandpass observation, where each field in the one MS had a different orientation. Splitting out the MS into a single field still carried with it all items from the original FEED table, even though a singly entry was used. The extra check I added ensures that the correct orientation can be deduced if a single FEED is referenced in the data, even if the FEED table has multiple entries. 