### PR TITLE
Add option to restore FIELD direction in fix_ms_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ASKAP utilities for updating MeasurementSets for external imagers.
 
 ASKAP MSs are produced in a way that breaks compatibility with most other imagers (e.g. CASA, WSclean). Here we provide two modules (with CLI hooks) that perform the fixes that need to be applied in order to produce astronomically correct imagers with non-YandaSoft imagers:
 
-1. `fix_ms_dir` : ASKAP MeasurementSets are phased towards the centre of field, but not the centre of its given beam. This utility reads the appropriate offsets to the beam centre from the `BEAM_OFFSET` and updates the `FIELD` table, as well as the phase and delay reference columns.
+1. `fix_ms_dir` : ASKAP MeasurementSets are phased towards the centre of field, but not the centre of its given beam. This utility reads the appropriate offsets to the beam centre from the `BEAM_OFFSET` and updates the `FIELD` table, as well as the phase and delay reference columns. An option is also available to restore the `FIELD` table directions to the original directions if `fix_ms_dir` has already been run.
 
 2. `fix_ms_corrs` : ASKAP MeasurementSets, as calibrated by the obervatory, provide correlations in the instrument frame. ASKAP has a unique 'roll' axis which means, in principle, the instrument frame can be at any arbitrary rotation on the sky. This utility applies the appropriate rotation matrix to the visibilities such the 'X' is aligned North-South and 'Y' is aligned East-West (IAU convention). Further, ASKAPsoft defines Stokes I as $I=XX+YY$, whereas most other telescopes use $I=\frac{1}{2}(XX+YY)$ (note this also applies to all other Stokes paramters). This factor is also corrected for here at the same time as the rotation. If you have calibrated with non-ASKAPsoft tools, you may need to use the `--no-fix-stokes-factor` option, which will disable the factor of two correction and just do a rotation.
 
@@ -81,10 +81,11 @@ usage: fix_ms_dir [-h] [ms]
 ASKAP utility - update the pointing centre of a beam in an MS. - Allows imaging by CASA or wsclean.
 
 positional arguments:
-  ms          Measurement set to update (default: None)
+  ms             Measurement set to update (default: None)
 
-optional arguments:
-  -h, --help  show this help message and exit
+options:
+  -h, --help     show this help message and exit
+  -r, --restore  Switch to restore direction to the original ASKAPsoft pipeline direction. (default: False)
   ```
 
 ## Contribution

--- a/fixms/fix_ms_dir.py
+++ b/fixms/fix_ms_dir.py
@@ -232,10 +232,9 @@ def restore_ms_dir(ms):
     """Restore the direction to the ASKAPsoft standard."""
 
     if tableexists("%s/FIELD_OLD" % (ms)):
-
         logger.info("Restoring FIELD directions in %s" % (ms))
         tp = table("{}/FIELD".format(ms), readonly=False, ack=False)
-        fp = table("%s/FIELD_OLD" %(ms), readonly=True, ack=False)
+        fp = table("%s/FIELD_OLD" % (ms), readonly=True, ack=False)
         field_dir = fp.getcol("PHASE_DIR")
         tp.putcol("PHASE_DIR", field_dir)
         tp.putcol("DELAY_DIR", field_dir)
@@ -243,8 +242,10 @@ def restore_ms_dir(ms):
         tp.flush()
         tp.close()
     else:
-        logger.warning("No `FIELD_OLD` table in %s - cannot restore direction if direction has not changed." % (ms))
-
+        logger.warning(
+            "No `FIELD_OLD` table in %s - cannot restore direction if direction has not changed."
+            % (ms)
+        )
 
 
 def fix_ms_dir(ms):
@@ -388,9 +389,10 @@ def cli():
         "ms", help="Measurement set to update", type=str, default=None, nargs="?"
     )
     parser.add_argument(
-        "-r", "--restore",
+        "-r",
+        "--restore",
         action="store_true",
-        help="Switch to restore direction to the original ASKAPsoft pipeline direction"
+        help="Switch to restore direction to the original ASKAPsoft pipeline direction",
     )
     # Parse the command line
     args = parser.parse_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixms"
-version = "0.1.5"
+version = "0.2.0"
 description = ""
 authors = ["Alec Thomson (S&A, Kensington WA) <alec.thomson@csiro.au>"]
 readme = "README.md"


### PR DESCRIPTION
Adds an option to restore the FIELD direction if fix_ms_dir has created a FIELD_OLD table. 